### PR TITLE
Changed win condition to uncovered tiles

### DIFF
--- a/Shared/MinesweeperGrid.swift
+++ b/Shared/MinesweeperGrid.swift
@@ -50,25 +50,15 @@ extension Grid2D where Tile == MinesweeperTile {
         }
 
         // Check win condition
-
-        // Check if all mines have a flag
-        let mines = memory.filter { tile in
-            tile.content == .mine
-        }
-        let flaggedMines = mines.filter { tile in
-            tile.state == .flagged
-        }
-        let allMinesAreFlagged = mines.count == flaggedMines.count
-
-        // Check if all empty tiles *don't* have a flag
         let emptyTiles = memory.filter { tile in
             tile.content == .empty
         }
-        let nonMineTilesDontHaveFlags = emptyTiles.allSatisfy { tile in
-            tile.state != .flagged
+        
+        let uncoveredTiles = memory.filter { tile in
+            tile.state == .exposed
         }
 
-        if allMinesAreFlagged && nonMineTilesDontHaveFlags {
+        if  emptyTiles.count == uncoveredTiles.count {
             return .won
         } else {
             return .running


### PR DESCRIPTION
Right now the game lets you win when you flagged all mines, this is wrong because you can brute force a win at the end of the game, this change will force players to uncover every tile not connected to a mine